### PR TITLE
Fix forwarding kwargs in ghostwrite (#65)

### DIFF
--- a/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_bare_and_explicit.txt
+++ b/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_bare_and_explicit.txt
@@ -2,7 +2,7 @@ def test_some_func(self) -> None:
     @given(
         x=integers(min_value=1)
     )
-    def execute(kwargs) -> None:
+    def execute(**kwargs) -> None:
         test_samples.pyicontract_hypothesis.sample_module.some_func(**kwargs)
 
     execute()
@@ -11,7 +11,7 @@ def test_another_func(self) -> None:
     @given(
         x=integers(min_value=1).filter(lambda x: square_greater_than_zero(x))
     )
-    def execute(kwargs) -> None:
+    def execute(**kwargs) -> None:
         test_samples.pyicontract_hypothesis.sample_module.another_func(**kwargs)
 
     execute()

--- a/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_non_bare_and_explicit.py
+++ b/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_non_bare_and_explicit.py
@@ -14,7 +14,7 @@ class TestWithInferredStrategies(unittest.TestCase):
         @given(
             x=integers(min_value=1)
         )
-        def execute(kwargs) -> None:
+        def execute(**kwargs) -> None:
             test_samples.pyicontract_hypothesis.sample_module.some_func(**kwargs)
 
         execute()
@@ -23,7 +23,7 @@ class TestWithInferredStrategies(unittest.TestCase):
         @given(
             x=integers(min_value=1).filter(lambda x: square_greater_than_zero(x))
         )
-        def execute(kwargs) -> None:
+        def execute(**kwargs) -> None:
             test_samples.pyicontract_hypothesis.sample_module.another_func(**kwargs)
 
         execute()

--- a/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_well_formatted_with_two_arguments.py
+++ b/test_samples/pyicontract_hypothesis/expected_ghostwrites/for_test_well_formatted_with_two_arguments.py
@@ -15,7 +15,7 @@ class TestWithInferredStrategies(unittest.TestCase):
             a=integers(),
             b=integers()
         )
-        def execute(kwargs) -> None:
+        def execute(**kwargs) -> None:
             test_samples.pyicontract_hypothesis.well_formatted_with_two_arguments.add(**kwargs)
 
         execute()

--- a/tests/pyicontract_hypothesis/test_ghostwrite.py
+++ b/tests/pyicontract_hypothesis/test_ghostwrite.py
@@ -5,11 +5,9 @@ import io
 import os
 import pathlib
 import re
-import shutil
 import sys
 import tempfile
 import unittest
-from typing import List
 
 from icontract_hypothesis.pyicontract_hypothesis import _general, _ghostwrite, main
 


### PR DESCRIPTION
When we unpack the arguments in ``given``, we need to be careful that
the executing test function also expects variable keyword arguments
instead of a single function argument.

Fixes #64.